### PR TITLE
docs: align README wording with published v2.0 releases

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -102,8 +102,6 @@ builder.Services.AddEnhancedSwaggerGenODataWithQueryOptions(
         MaxTop = 100
     });
 
-builder.Services.AddSwaggerGen();
-
 var app = builder.Build();
 
 app.UseSwagger();
@@ -146,6 +144,8 @@ services.AddEnhancedSwaggerGenOData(options =>
 #### `AddEnhancedSwaggerGenODataWithQueryOptions`
 
 Same as above + registers `ODataQueryOptionsDocumentFilter` and applies `ODataQueryOptionsSettings`.
+
+This method already wires `AddSwaggerGen(...)`; do not add a second bare `AddSwaggerGen()` call after it in the same registration path.
 
 ```csharp
 services.AddEnhancedSwaggerGenODataWithQueryOptions(
@@ -194,7 +194,7 @@ Plan migration to `AddEnhancedSwaggerGenOData(...)` or `AddEnhancedSwaggerGenODa
 
 ### SwaggerGenODataOptions
 
-Container for `SwaggerGeneratorODataOptions`.
+Container for `SwaggerODataGeneratorOptions` (via the `SwaggerGeneratorODataOptions` property).
 
 ### SwaggerODataGeneratorOptions
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ app.MapControllers();
 app.Run();
 ```
 
-## 📖 Upcoming in v2.0 (Unreleased)
+## 📖 v2.0 Feature Set (Released)
 
 ### Enhanced Features
 
@@ -150,7 +150,8 @@ app.Run();
 - **Method Overload Support**: Multiple actions with same name are correctly documented
 - **Better HTTP Semantics**: Accurate methods, status codes, request/response schemas
 
-Track current release status in [RELEASE_NOTES.md](./RELEASE_NOTES.md#unreleased).
+These features shipped in the v2.0 line (starting with v2.0.0).
+Track version-by-version status in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 See [ENHANCED_FEATURES.md](./ENHANCED_FEATURES.md) for detailed feature documentation.
 
 ## 📊 Comparison with Other Approaches

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If animation is not shown in your Markdown viewer, open [`Images/swagger-ui-demo
 
 ## ✨ Features
 
-- 🔍 **Full OData Query Support** - Automatic documentation of `$filter`, `$select`, `$expand`, `$orderby`, `$top`, `$skip`, `$count`, `$search`
+- 🔍 **Full OData Query Support** - Automatic documentation of `$filter`, `$select`, `$expand`, `$orderby`, `$top`, `$skip`, `$count`, `$format` (and `$search` when enabled)
 - 📡 **Real Endpoint-Based Generation** - Uses actual ASP.NET Core endpoint routing for accurate API documentation
 - 🎯 **Complete OData Path Coverage** - Entity sets, singletons, functions, actions, property access, `$value`, `$ref`
 - 🚀 **HTTP Method Accuracy** - Correctly captures GET, POST, PUT, PATCH, DELETE with proper request/response schemas
@@ -76,8 +76,6 @@ public void ConfigureServices(IServiceCollection services)
         }
     );
 
-    // Add Swashbuckle services
-    services.AddSwaggerGen();
 }
 
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -130,8 +128,6 @@ builder.Services.AddEnhancedSwaggerGenODataWithQueryOptions(
             Version = "v1"
         });
     });
-
-builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 app.UseSwagger();


### PR DESCRIPTION
## Summary
Post-release docs consistency cleanup after publishing v2.0.1.

## What changed
- Updated README section title:
  - from `Upcoming in v2.0 (Unreleased)`
  - to `v2.0 Feature Set (Released)`
- Replaced stale `RELEASE_NOTES.md#unreleased` pointer with a version-aware release-notes link.
- Kept `RELEASE_NOTES.md` unchanged (already consistent for released state).

## Review method used
Ran repo audit with `repomix --stdout` piped into `codex exec`, then applied only must-fix consistency edits.
